### PR TITLE
fix hullbreach to work with the new (dev) version of BDA

### DIFF
--- a/ModuleHullBreach.cs
+++ b/ModuleHullBreach.cs
@@ -286,6 +286,11 @@ namespace HullBreach
                 isHullBreached = true;
                 DamageState = "Critical";
             }
+            else
+            {
+                isHullBreached = false;
+                DamageState = "None";
+            }
 
             if (forceHullBreach == true) //forcing if testing hull breach or if Catastrophic damage triggerd
             {


### PR DESCRIPTION
Right now part hitpoints are updated during the first update, and hullbreach manages to cause breaches all over in the meantime. Adding a check to stop hullbreach when parts are healthy. This would also permit repairs and stuff.