### PR TITLE
Fix version file syntax

### DIFF
--- a/Distribution/GameData/HullBreach/HullBreach.version
+++ b/Distribution/GameData/HullBreach/HullBreach.version
@@ -1,7 +1,7 @@
 ﻿{
     "NAME":"HullBreach",
     "URL":"https://github.com/gomker/HullBreach/blob/master/Distribution/GameData/HullBreach/HullBreach.version",
-    "DOWNLOAD":"https://github.com/Gomker/HullBreach/releases/tag/v1.7.0.5,
+    "DOWNLOAD":"https://github.com/Gomker/HullBreach/releases/tag/v1.7.0.5",
     "GITHUB":
     {
         "USERNAME":"gomker",


### PR DESCRIPTION
The `DOWNLOAD` property is missing a quote, now it's fixed.

FYI to @gomker.